### PR TITLE
Refactoring: Use `SqlBag` to process multiple SQL stmts per operation

### DIFF
--- a/cratedb_fivetran_destination/model.py
+++ b/cratedb_fivetran_destination/model.py
@@ -1,4 +1,5 @@
 import typing as t
+from textwrap import dedent
 
 import sqlalchemy as sa
 from attr import Factory
@@ -88,3 +89,20 @@ class FivetranKnowledge:
 class TableInfo:
     fullname: str
     primary_keys: t.List[str] = Factory(list)
+
+
+@define
+class SqlBag:
+    """
+    A little bag of multiple SQL statements.
+    """
+
+    statements: t.List[str] = Factory(list)
+
+    def add(self, sql: str):
+        self.statements.append(dedent(sql).strip())
+        return self
+
+    def execute(self, connection: sa.Connection):
+        for sql in self.statements:
+            connection.execute(sa.text(sql))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import sqlalchemy as sa
+
+
+@pytest.fixture
+def engine():
+    return sa.create_engine("crate://")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,11 +17,6 @@ def run(command: str, background: bool = False):
     return None
 
 
-@pytest.fixture
-def engine():
-    return sa.create_engine("crate://")
-
-
 @pytest.fixture(autouse=True)
 def reset_tables(engine):
     with engine.connect() as connection:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,7 @@
+from cratedb_fivetran_destination.model import SqlBag
+
+
+def test_sqlbag(engine):
+    bag = SqlBag().add("SELECT 23").add("SELECT 42")
+    with engine.connect() as connection:
+        bag.execute(connection)


### PR DESCRIPTION
## About

GH-20 needs to process multiple SQL statements per operation. Using an `SqlBag` to bundle them will yield a better object model by providing symmetry across the board.
