### PR TITLE
OCI: Provide container image `ghcr.io/crate/cratedb-fivetran-destination`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+*
+
+!.git
+!docs
+!release
+!cratedb_fivetran_destination
+
+!*.cfg
+!*.md
+!*.py
+!*.rst
+!*.toml
+!*.txt
+!LICENSE
+!MANIFEST.in

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@
 
 version: 2
 updates:
+
   - package-ecosystem: "pip"
     directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/release/oci"
     schedule:
       interval: "weekly"
 

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -1,0 +1,150 @@
+# Stage OCI container images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
+# The image is available per `ghcr.io/crate/cratedb-fivetran-destination`.
+name: OCI
+
+on:
+
+  # Build images when merging to `main` and when running a release.
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*.*.*'
+
+  # Build images on each pull request.
+  # Remark: Activate only when needed, it will eat a lot of resources. The alternative
+  #         is to build manually / on-demand, by using the `workflow_dispatch` feature,
+  #         available through the GHA web UI.
+  pull_request:
+
+  # Produce a nightly image every day at 6 a.m. CEST.
+  schedule:
+    - cron: '0 4 * * *'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+# The name for the produced image at ghcr.io.
+env:
+  IMAGE_NAME: "${{ github.repository }}"
+  RECIPE_PATH: "release/oci"
+
+jobs:
+  build_and_test:
+    runs-on: "ubuntu-22.04"
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Build wheel package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Upload wheel package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.os }}-wheel-${{ github.sha }}
+          path: dist/*.whl
+          retention-days: 7
+
+      - name: Run tests
+        run: |
+          if [[ -f ${{ env.RECIPE_PATH }}/test.yml ]]; then
+            export DOCKER_BUILDKIT=1
+            export COMPOSE_DOCKER_CLI_BUILD=1
+            docker compose --file ${{ env.RECIPE_PATH }}/test.yml build
+            docker compose --file ${{ env.RECIPE_PATH }}/test.yml run sut
+          fi
+
+  oci:
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Define image name and tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # List of OCI images to use as base name for tags
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+          # Generate OCI image tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=schedule,pattern=nightly
+
+      - name: Inspect metadata
+        run: |
+          echo "Tags:      ${{ steps.meta.outputs.tags }}"
+          echo "Labels:    ${{ steps.meta.outputs.labels }}"
+
+      - name: Install QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
+
+      - name: Install Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache OCI layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.RECIPE_PATH }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Display git status
+        run: |
+          set -x
+          git describe --tags --always
+          git status

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches: [ main ]
-  pull_request: ~
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Type mapping: Mapped `SQLAlchemy.DateTime` to `Fivetran.UTC_DATETIME`
 - UI: Removed unneeded form fields. Added unit test.
 - CLI: Provided command-line interface for `--port` and `--max-workers` options
+- OCI: Provided container image `ghcr.io/crate/cratedb-fivetran-destination`
 
 ## v0.0.0 - 2025-02-17
 - Added project skeleton

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,12 @@
 # CrateDB Fivetran Destination Changelog
 
-
 ## Unreleased
 - Added implementation for `DescribeTable` gRPC method
 - Added implementation for `AlterTable` gRPC method
 - Type mapping: Mapped `Fivetran.SHORT` to `SQLAlchemy.SmallInteger`
 - Type mapping: Mapped `SQLAlchemy.DateTime` to `Fivetran.UTC_DATETIME`
 - UI: Removed unneeded form fields. Added unit test.
+- CLI: Provided command-line interface for `--port` and `--max-workers` options
 
 ## v0.0.0 - 2025-02-17
 - Added project skeleton

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -68,8 +68,24 @@ docker run --rm -it \
   --tester-type destination --port 50052
 ```
 
+## OCI builds
 
-## Release
+Build OCI images on your workstation.
+```shell
+export BUILDKIT_PROGRESS=plain
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
+```
+```shell
+docker build --tag=local/cratedb-fivetran-destination --file=release/oci/Dockerfile .
+```
+Roughly verify that invocation works.
+```shell
+docker run --rm local/cratedb-fivetran-destination --version
+```
+
+## Python package release
+
 ```shell
 poe release
 ```

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -50,7 +50,7 @@ docker run --rm \
 
 Start gRPC destination server.
 ```bash
-python -m cratedb_fivetran_destination.main
+cratedb-fivetran-destination
 ```
 
 [Install the gcloud CLI] and start [Fivetran destination tester].

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install --upgrade cratedb-fivetran-destination
 
 Start gRPC destination server.
 ```bash
-python -m cratedb_fivetran_destination.main
+cratedb-fivetran-destination --port=50052 --max-workers=1
 ```
 
 ## Project Information

--- a/README.md
+++ b/README.md
@@ -47,14 +47,23 @@ see [CrateDB Installation], or [CrateDB Cloud Console].
 ## Installation
 
 ```bash
-pip install --upgrade cratedb-fivetran-destination
+uv tool install --upgrade cratedb-fivetran-destination
 ```
 
 ## Usage
 
-Start gRPC destination server.
+Start gRPC destination server. Note the parameters are optional.
 ```bash
 cratedb-fivetran-destination --port=50052 --max-workers=1
+```
+
+## OCI
+
+You can use the OCI image [ghcr.io/crate/cratedb-fivetran-destination] at your
+disposal. CI is building image variants for each pr, each night, and for
+GA releases.
+```bash
+docker run --rm --publish=50052:50052 ghcr.io/crate/cratedb-fivetran-destination:nightly
 ```
 
 ## Project Information
@@ -91,6 +100,7 @@ The project uses the Apache license, like CrateDB itself.
 [CrateDBVectorStore]: https://github.com/crate/cratedb-fivetran-destination/blob/cratedb/docs/vectorstores.ipynb
 [crate]: https://pypi.org/project/crate/
 [Fivetran SDK Development Guide]: https://github.com/fivetran/fivetran_sdk/blob/main/development-guide.md
+[ghcr.io/crate/cratedb-fivetran-destination]: https://github.com/crate/cratedb-fivetran-destination/pkgs/container/cratedb-fivetran-destination
 
 [Changelog]: https://github.com/crate/cratedb-fivetran-destination/blob/cratedb/CHANGES.md
 [Community Forum]: https://community.cratedb.com/

--- a/cratedb_fivetran_destination/cli.py
+++ b/cratedb_fivetran_destination/cli.py
@@ -1,0 +1,38 @@
+import logging
+
+import click
+
+from cratedb_fivetran_destination.main import start_server
+from cratedb_fivetran_destination.util import setup_logging
+
+logger = logging.getLogger()
+
+
+@click.command()
+@click.version_option()
+@click.pass_context
+@click.option("--port", "-p", type=int, default=50052, help="Port to listen on. Default: 50052")
+@click.option(
+    "--max-workers",
+    "-w",
+    type=int,
+    default=1,
+    help="The maximum number of threads that can be used. Default: 1",
+)
+def main(ctx: click.Context, port: int, max_workers: int) -> None:
+    """
+    Start Fivetran CrateDB Destination gRPC server.
+
+    The executable needs to do the following:
+
+    - Accept a --port argument that takes an integer as a port number to listen to.
+    - Listen on both IPV4 (i.e. 0.0.0.0) and IPV6 (i.e ::0), but if only one is possible,
+      it should listen on IPV4.
+
+    -- https://github.com/fivetran/fivetran_sdk/blob/main/development-guide.md#command-line-arguments
+    """
+    setup_logging()
+    server = start_server(port=port, max_workers=max_workers)
+    logger.info(f"Fivetran CrateDB Destination gRPC server started on port {port}")
+    server.wait_for_termination()
+    logger.info("Fivetran CrateDB Destination gRPC server terminated")

--- a/cratedb_fivetran_destination/main.py
+++ b/cratedb_fivetran_destination/main.py
@@ -21,7 +21,6 @@ from cratedb_fivetran_destination.util import (
     LOG_SEVERE,
     LOG_WARNING,
     log_message,
-    setup_logging,
 )
 
 from . import read_csv
@@ -309,19 +308,11 @@ class CrateDBDestinationImpl(destination_sdk_pb2_grpc.DestinationConnectorServic
         return f'"{request.schema_name}"."{table_name}"'
 
 
-def start_server():
-    setup_logging()
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    server.add_insecure_port("[::]:50052")
+def start_server(port: int = 50052, max_workers: int = 1) -> grpc.Server:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
+    server.add_insecure_port(f"[::]:{port}")
     destination_sdk_pb2_grpc.add_DestinationConnectorServicer_to_server(
         CrateDBDestinationImpl(), server
     )
     server.start()
     return server
-
-
-if __name__ == "__main__":  # pragma: no cover
-    server = start_server()
-    logger.info("Destination gRPC server started")
-    server.wait_for_termination()
-    logger.info("Destination gRPC server terminated")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ keywords = [
   "database destination adapter",
   "fivetran",
 ]
-license = { text = "Apache License 2.0" }
+license = "Apache-2.0"
+license-files = [ "LICENSE" ]
 authors = [ { name = "CrateDB Developers", email = "office@crate.io" } ]
 requires-python = ">=3.9"
 classifiers = [
@@ -30,7 +31,6 @@ classifiers = [
   "Intended Audience :: End Users/Desktop",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: MacOS",
   "Operating System :: POSIX",
   "Operating System :: Unix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dynamic = [
 ]
 
 dependencies = [
+  "click<9",
   "google<3.1",
   "grpcio<1.71",
   "grpcio-tools<1.71",
@@ -97,13 +98,16 @@ optional-dependencies.test = [
   "pretend<2",
   "pytest<9",
   "pytest-cov<7",
+  "pytest-mock<4",
 ]
 urls."Release Notes" = "https://github.com/crate/cratedb-fivetran-destination/releases"
 
 urls.Repository = "https://github.com/crate/cratedb-fivetran-destination"
 
+scripts.cratedb-fivetran-destination = "cratedb_fivetran_destination.cli:main"
+
 [tool.setuptools]
-packages = [ "cratedb_fivetran_destination" ]
+packages = [ "cratedb_fivetran_destination", "cratedb_fivetran_destination.sdk_pb2" ]
 
 [tool.ruff]
 line-length = 100

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -1,0 +1,54 @@
+# Stage 1: Build wheel package
+FROM python:3.13-slim-bookworm AS build
+
+ARG BUILD=/usr/src
+
+# Configure operating system
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
+
+# Install prerequisites
+RUN apt-get update
+RUN apt-get --yes install --no-install-recommends --no-install-suggests git wget
+
+RUN pip install build
+RUN python -m build --version
+
+COPY . ${BUILD}
+RUN python -m build --wheel ${BUILD}
+
+
+FROM python:3.13-slim-bookworm AS package
+
+ARG BUILD=/usr/src
+
+# Configure operating system.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
+
+# Configure build environment.
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV UV_COMPILE_BYTECODE=true
+ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_DOWNLOADS=never
+ENV UV_SYSTEM_PYTHON=true
+
+# Configure runtime environment.
+ENV PATH=/root/.local/bin:$PATH
+
+# Provide wheel package.
+COPY --from=build ${BUILD}/dist/*.whl /tmp
+
+# Install package.
+RUN \
+    --mount=type=cache,id=pip,target=/root/.cache/pip \
+    --mount=type=cache,id=uv,target=/root/.cache/uv \
+    true \
+    && pip install uv \
+    && uv tool install --upgrade "$(ls /tmp/*.whl)"
+
+# Copy `selftest.sh` to the image.
+COPY release/oci/selftest.sh /usr/local/bin
+
+# Run the program by default.
+ENTRYPOINT ["cratedb-fivetran-destination"]

--- a/release/oci/selftest.sh
+++ b/release/oci/selftest.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Fail on error.
+set -e
+
+# Display all commands.
+# set -x
+
+echo "Invoking adapter"
+cratedb-fivetran-destination --version

--- a/release/oci/test.yml
+++ b/release/oci/test.yml
@@ -1,0 +1,7 @@
+services:
+  sut:
+    build:
+      context: ../..
+      dockerfile: release/oci/Dockerfile
+    entrypoint: ""
+    command: selftest.sh

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import pytest
+from click.testing import CliRunner
+
+from cratedb_fivetran_destination.cli import main
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_cli_version(cli_runner, mocker):
+    """
+    CLI test: Invoke `cratedb-fivetran-destination --version`.
+    """
+    result = cli_runner.invoke(
+        main,
+        args="--version",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_real_mocked(cli_runner, mocker):
+    """
+    CLI test: Invoke `cratedb-fivetran-destination`.
+    """
+    mocker.patch("cratedb_fivetran_destination.cli.start_server")
+    result = cli_runner.invoke(
+        main,
+        args="",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
## About
Provide package per OCI image, for container use (Docker, Podman, Kubernetes, etc.).

## Synopsis
Display version.
```bash
docker run --rm ghcr.io/crate/cratedb-fivetran-destination:pr-26 --version
```

Start gRPC server.
```bash
docker run --rm --publish=50052:50052 ghcr.io/crate/cratedb-fivetran-destination:pr-26
```
