### PR TITLE
CI: Trim configuration for PyPI trusted publishing

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -66,6 +66,3 @@ jobs:
       - name: Publish package to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## About

Following @surister's suggestions to use trusted publishing with PyPI as exercised per [release_python.yml](https://github.com/crate/cratedb-sqlparse/blob/main/.github/workflows/release_python.yml), I was pleased about the same effortless and fluent experience on this project per [release-pypi.yml](https://github.com/crate/cratedb-fivetran-destination/blob/main/.github/workflows/release-pypi.yml). It works really well!

## Improvement

When using trusted publishing, explicitly configuring PyPI authentication might not be required any longer, as @surister's invocation of `uv publish` suggests? In this spirit, let's also try to remove it here with the `pypa/gh-action-pypi-publish` recipe?

## Testing

It could only be tested end-to-end when extending the workflow to publish to test.pypi.org instead of the real one, for, well, testing purposes. Currently, the corresponding workflow stops after building the artefacts, and will only invoke the publish operation when actually tagging the repository.
