### PR TITLE
CI: Stop building OCI images and standalone artifacts

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -11,11 +11,11 @@ on:
       - '*'
 
   # Build application on each pull request for validation purposes.
-  pull_request:
+  # pull_request:
 
   # Build application each night for validation purposes.
-  schedule:
-    - cron: '0 4 * * *'
+  # schedule:
+  #   - cron: '0 4 * * *'
 
   # Allow the job to be triggered manually.
   workflow_dispatch:

--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -15,11 +15,11 @@ on:
   # Remark: Activate only when needed, it will eat a lot of resources. The alternative
   #         is to build manually / on-demand, by using the `workflow_dispatch` feature,
   #         available through the GHA web UI.
-  pull_request:
+  # pull_request:
 
   # Produce a nightly image every day at 6 a.m. CEST.
-  schedule:
-    - cron: '0 4 * * *'
+  # schedule:
+  #   - cron: '0 4 * * *'
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,4 +71,4 @@ jobs:
           flags: unittests
           env_vars: OS,PYTHON
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 - Dependencies: Updated to `sqlalchemy-cratedb==0.42.0.dev2`
-- Build: Add target to generate `requirements.txt`, and add the generated file
+- Build: Added target to generate `requirements.txt`, and added the generated file
+- CI: Stopped building OCI images and standalone artifacts
 
 ## v0.0.2 - 2025-05-01
 - CLI: Added `--host` option to define on which host to listen on.


### PR DESCRIPTION
Fivetran runs a build pipeline on their own, which starts from the repository and a `requirements.txt` file.

- See GH-36.
