### PR TITLE
CI: Use `macos-15-intel` for macOS Intel builds

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          "macos-13",        # Intel
+          "macos-15-intel",  # Intel, available until August 2027, see https://github.com/actions/runner-images/issues/13045.
           "macos-latest",    # ARM
           "ubuntu-latest",   # Intel
           # "windows-latest",  # Intel


### PR DESCRIPTION
> **Build for OS macos-13**
> This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated.

> **Build for OS macos-13**
> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead.

For more details, see:
- https://github.com/actions/runner-images/issues/13045
- https://github.com/actions/runner-images/issues/13046
