### PR TITLE
CI: Don't build OCI and application bundle on each PR to save resources

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -11,7 +11,8 @@ on:
       - '*'
 
   # Build application on each pull request for validation purposes.
-  pull_request:
+  # Remark: Disabled to conserve CI resources. Use workflow_dispatch for manual builds.
+  # pull_request:
 
   # Build application each night for validation purposes.
   # schedule:

--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -12,10 +12,8 @@ on:
       - '*'
 
   # Build images on each pull request.
-  # Remark: Activate only when needed, it will eat a lot of resources. The alternative
-  #         is to build manually / on-demand, by using the `workflow_dispatch` feature,
-  #         available through the GHA web UI.
-  pull_request:
+  # Remark: Disabled to conserve CI resources. Use workflow_dispatch for manual builds.
+  # pull_request:
 
   # Produce a nightly image every day at 6 a.m. CEST.
   # schedule:


### PR DESCRIPTION
What the title says.