### PR TITLE
Add documentation from Fivetran blueprints

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -6,9 +6,9 @@ name: "Release: Application bundle"
 on:
 
   # Build and publish application when running a release.
-  push:
-    tags:
-      - '*'
+  #push:
+  #  tags:
+  #    - '*'
 
   # Build application on each pull request for validation purposes.
   # Remark: Disabled to conserve CI resources. Use workflow_dispatch for manual builds.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,16 @@
 
 ## Unreleased
 
-- Model: Added refinements from recent commits to Fivetran
-  Partner SDK up until commit 3037ce4 (Apr 21, 2026).
-- Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
-- Testing: Updated to `sdk-tester:2.26.0420.001` (Apr 21, 2026)
-- Testing: Skipped live mode integration test, the feature has
-  been put [on hold][live mode pause] by Fivetran.
-- Dependencies: Updated to grpcio==1.78.*
 - Model: Removed workaround for `_`-prefixed column names.
   The package now requires CrateDB 6.2 or higher.
+- Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
+- Testing: Updated to `sdk-tester:2.26.0420.001` (Apr 21, 2026)
+- Model: Added refinements from recent commits to Fivetran
+  Partner SDK up until commit 3037ce4 (Apr 21, 2026).
+- Testing: Skipped live mode integration test, the feature has
+  been put [on hold][live mode pause] by Fivetran.
 - Added documentation from Fivetran blueprints
+- Dependencies: Updated to grpcio==1.78.*
 
 [live mode pause]: https://github.com/crate/cratedb-fivetran-destination/issues/148
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Dependencies: Updated to grpcio==1.78.*
 - Model: Removed workaround for `_`-prefixed column names.
   The package now requires CrateDB 6.2 or higher.
+- Added documentation from Fivetran blueprints
 
 [live mode pause]: https://github.com/crate/cratedb-fivetran-destination/issues/148
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -9,7 +9,7 @@ with the [Fivetran SDK Development Guide].
 ```shell
 git clone https://github.com/crate/cratedb-fivetran-destination.git
 cd cratedb-fivetran-destination
-uv venv --python 3.13 --seed .venv
+uv venv --python 3.14 --seed .venv
 source .venv/bin/activate
 uv pip install --upgrade --editable='.[develop,test]'
 ```
@@ -27,7 +27,7 @@ poe format
 :::{note}
 Use `gcloud auth login` to authenticate the Google SDK so you can pull the OCI images.
 ```shell
-$ docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:2.25.0131.001
+$ docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:2.26.0127.001
 error getting credentials - err: exit status 1, out: `You do not currently have an active account selected. See https://cloud.google.com/sdk/docs/authorizing for more information.`
 ```
 :::

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ ERPs, and files to data warehouses, data lakes, and more.
 massive amounts of data in near real-time, even with complex queries. 
 CrateDB is based on Lucene and Elasticsearch, but [compatible with PostgreSQL].
 
+Note: **Operating the package needs CrateDB 6.2 or higher.**
+
 ## What's inside
 
-This project and repository provides:
+The source code of the `cratedb-fivetran-destination` package, which implements
+the [CrateDB destination adapter for Fivetran]. It works with both [CrateDB] and
+[CrateDB Cloud].
 
-- The source code of the `cratedb-fivetran-destination` package, which implements
-  the [CrateDB destination adapter for Fivetran]. It works with both [CrateDB] and
-  [CrateDB Cloud]. Operating the package successfully needs CrateDB 6.2 or higher.
-
-- The public [issue tracker] for this project. Please use it
-  to report problems, and stay informed about their resolutions.
+The public [issue tracker] for this package. Please use it
+to report problems, and stay informed about their resolutions.
 
 ## Status
 
@@ -51,23 +51,27 @@ to improve quality and fix bugs.
 For installation per [PyPI package][PyPI], [OCI image], [standalone executable],
 and usage information, please visit the [handbook] document.
 
-For building the application, or hacking on it, please refer to the
-[development sandbox] documentation.
+In order to set up a development environment on your workstation, please
+refer to the [development sandbox] documentation. When you see the software
+tests succeed, you should be ready to start hacking.
 
 ## Project Information
 
 ### Acknowledgements
+
 Kudos to the authors of all the many software components this library is
 inheriting from and building upon.
 
 ### Contributing
+
 The CrateDB connector for Fivetran is an open-source project, and is
 [managed on GitHub].
 Feel free to use the adapter as provided or else modify / extend it
 as appropriate for your own applications. We appreciate contributions of any kind.
 
 ### License
-The project uses the Apache license, like CrateDB itself.
+
+The project uses the Apache License, like CrateDB.
 
 
 [compatible with PostgreSQL]: https://cratedb.com/docs/guide/feature/postgresql-compatibility/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ to improve quality and fix bugs.
 For installation per [PyPI package][PyPI], [OCI image],
 and usage information, please visit the [handbook] document.
 
-In order to set up a development environment on your workstation, please
+To set up a development environment on your workstation, please
 refer to the [development sandbox] documentation. When you see the software
 tests succeed, you should be ready to start hacking.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to improve quality and fix bugs.
 
 ## Usage
 
-For installation per [PyPI package][PyPI], [OCI image], [standalone executable],
+For installation per [PyPI package][PyPI], [OCI image],
 and usage information, please visit the [handbook] document.
 
 In order to set up a development environment on your workstation, please
@@ -84,7 +84,6 @@ The project uses the Apache License, like CrateDB.
 [handbook]: https://github.com/crate/cratedb-fivetran-destination/blob/main/docs/handbook.md
 [issue tracker]: https://github.com/crate/cratedb-fivetran-destination/issues
 [OCI image]: https://github.com/crate/cratedb-fivetran-destination/pkgs/container/cratedb-fivetran-destination
-[standalone executable]: https://github.com/crate/cratedb-fivetran-destination/releases
 
 [Changelog]: https://github.com/crate/cratedb-fivetran-destination/blob/main/CHANGES.md
 [Community Forum]: https://community.cratedb.com/

--- a/docs/fivetran/api-configuration.md
+++ b/docs/fivetran/api-configuration.md
@@ -1,0 +1,43 @@
+---
+name: API Configuration
+title: CrateDB API Configuration
+description: API Configuration for CrateDB Fivetran Destination
+hidden: false
+---
+
+# CrateDB API Configuration
+
+## Request
+
+```
+POST https://api.fivetran.com/v1/destinations
+```
+
+```json
+{
+  "group_id": "group_id",
+  "service": "big_query",
+  "region": "GCP_US_WEST1",
+  "time_zone_offset": "+3",
+  "trust_certificates": true,
+  "trust_fingerprints": true,
+  "run_setup_tests": true,
+  "daylight_saving_time_enabled": true,
+  "hybrid_deployment_agent_id": "hybrid_deployment_agent_id",
+  "private_link_id": "private_link_id",
+  "networking_method": "Directly",
+  "proxy_agent_id": "proxy_agent_id",
+  "config": {
+    "url": "crate://admin:password@testcluster.cratedb.net:4200/?ssl=true"
+  }
+}
+```
+
+## Config parameters
+
+| Name  | Description                                                   | 
+|-------|---------------------------------------------------------------|
+| url   | The database connection URL to your CrateDB database cluster. |
+
+The database connection URL needs to be in SQLAlchemy format.
+Example: `crate://admin:password@testcluster.cratedb.net:4200/?ssl=true`

--- a/docs/fivetran/api-configuration.md
+++ b/docs/fivetran/api-configuration.md
@@ -9,7 +9,7 @@ hidden: false
 
 ## Request
 
-```
+```text
 POST https://api.fivetran.com/v1/destinations
 ```
 

--- a/docs/fivetran/changelog.md
+++ b/docs/fivetran/changelog.md
@@ -1,0 +1,35 @@
+---
+name: Release Notes
+title: CrateDB Release Notes
+description: Changelog for CrateDB Fivetran Destination
+hidden: false
+---
+
+# Release Notes
+
+## January 2026
+
+Feature release.
+
+- Feature: Improved `AlterTable` operations
+- Feature: Added support for schema migrations
+- Feature: Added support for history and live mode
+- Types: Added support for Fivetran's `TIME_NAIVE` data type
+- Compatibility: Field `_fivetran_deleted` became optional
+
+## May 2025
+
+Maintenance release.
+
+## March 2025
+
+Initial release.
+
+- Added implementation for `DescribeTable` gRPC method
+- Added implementation for `AlterTable` gRPC method
+- Type mapping: Mapped `Fivetran.SHORT` to `SQLAlchemy.SmallInteger`
+- Type mapping: Mapped `SQLAlchemy.DateTime` to `Fivetran.UTC_DATETIME`
+- UI: Removed unneeded form fields. Added unit test.
+- CLI: Provided command-line interface for `--port` and `--max-workers` options
+- OCI: Provided container image `ghcr.io/crate/cratedb-fivetran-destination`
+- Packaging: Removed SDK from repository, build at build-time instead

--- a/docs/fivetran/overview.md
+++ b/docs/fivetran/overview.md
@@ -1,0 +1,95 @@
+---
+name: CrateDB
+title: CrateDB
+description: Overview about CrateDB Fivetran Destination
+hidden: false
+---
+
+# CrateDB {% badge text="Partner-Built" /%} {% badge text="Beta" /%} {% availabilityBadge connector="cratedb_destination" /%}
+
+Fivetran supports [CrateDB] as a destination.
+
+CrateDB is a distributed and scalable SQL database for storing and analyzing
+massive amounts of data in near real-time, even with complex SQL queries. It
+is PostgreSQL-compatible, and based on Lucene.
+CrateDB Cloud is a cloud data warehouse with enterprise features.
+
+Support works equally well across all editions:
+[CrateDB Cloud], [CrateDB Enterprise], [CrateDB OSS].
+
+This destination is [partner-built](/docs/partner-built-program). For any
+questions related to the CrateDB destination and its documentation,
+contact [CrateDB Support].
+
+------------------
+
+## Supported deployment models
+
+The CrateDB data warehouse supports the
+[SaaS](/deployment-models/saas-deployment),
+[Hybrid](/deployment-models/hybrid-deployment), and
+[Self-hosted](/docs/deployment-models/self-hosted-deployment)
+deployment models.
+
+------------------
+
+## Setup guide
+
+Follow the [step-by-step CrateDB setup guide](/docs/destinations/cratedb/setup-guide)
+to connect your CrateDB data warehouse with Fivetran.
+
+------------------
+
+## Type transformation and mapping
+
+The data types in your CrateDB data warehouse follow Fivetran's [standard data type storage](/docs/destinations#datatypes).
+
+We use the following data type conversions:
+
+| Fivetran Data Type | Destination Data Type | Notes |
+|--------------------|-----------------------| - |
+| BOOLEAN            | BOOLEAN               | |
+| SHORT              | SMALLINT              | |
+| INT                | INTEGER               | |
+| LONG               | BIGINT                | |
+| FLOAT              | FLOAT                 | |
+| DOUBLE             | DOUBLE                | |
+| BIGDECIMAL         | DECIMAL               | |
+| LOCALDATE          | TIMESTAMP             | |
+| LOCALDATETIME      | TIMESTAMP             | |
+| INSTANT            | TIMESTAMP             | |
+| STRING             | TEXT                  | |
+| XML                | TEXT                  | |
+| JSON               | OBJECT                | |
+| BINARY             | TEXT                  | |
+
+------------------
+
+## Limitations
+
+- Adding, removing, or modifying primary key columns is not supported.
+
+- Certain schema migration operations will incur a loss of primary key constraints.
+
+  CrateDB does not support creating primary key constraints on non-empty tables,
+  nor dropping them or changing their values. To provide schema migration and
+  history mode operations, the adapter uses table copy operations that drop primary
+  key constraints while they go.
+
+  This will effectively impact the schema migration operations [HISTORY_TO_SOFT_DELETE],
+  [SOFT_DELETE_TO_HISTORY], [HISTORY_TO_LIVE], and [LIVE_TO_HISTORY].
+
+- Certain column names are reserved for system purposes, so they will be rejected for users.
+  Example: `InvalidColumnNameException["_id" conflicts with system column]`.
+
+
+[CrateDB]: https://cratedb.com/database
+[CrateDB Cloud]: https://cratedb.com/database/editions/cloud
+[CrateDB Enterprise]: https://cratedb.com/database/editions/enterprise
+[CrateDB OSS]: https://cratedb.com/database/editions/oss
+[CrateDB Support]: https://cratedb.com/support
+
+[HISTORY_TO_SOFT_DELETE]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#history_to_soft_delete
+[SOFT_DELETE_TO_HISTORY]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#soft_delete_to_history
+[HISTORY_TO_LIVE]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#history_to_live
+[LIVE_TO_HISTORY]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#live_to_history

--- a/docs/fivetran/overview.md
+++ b/docs/fivetran/overview.md
@@ -76,11 +76,13 @@ We use the following data type conversions:
   history mode operations, the adapter uses table copy operations that drop primary
   key constraints while they go.
 
-  This will effectively impact the schema migration operations [HISTORY_TO_SOFT_DELETE],
-  [SOFT_DELETE_TO_HISTORY].
+  This will effectively impact the schema migration operations [HISTORY_TO_SOFT_DELETE]
+  and [SOFT_DELETE_TO_HISTORY].
 
-- Certain column names are reserved for system purposes, so they will be rejected for users.
-  Example: `InvalidColumnNameException["_id" conflicts with system column]`.
+- Certain column names are reserved for system purposes, so they will be
+  rejected for users. Example: `InvalidColumnNameException["_id" conflicts
+  with system column]`. Let us know on [CRATEDB-FIVETRAN-173] if this is a
+  problem for you so we can provide a workaround.
 
 
 [CrateDB]: https://cratedb.com/database
@@ -89,5 +91,6 @@ We use the following data type conversions:
 [CrateDB OSS]: https://cratedb.com/database/editions/oss
 [CrateDB Support]: https://cratedb.com/support
 
+[CRATEDB-FIVETRAN-173]: https://github.com/crate/cratedb-fivetran-destination/issues/173
 [HISTORY_TO_SOFT_DELETE]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#history_to_soft_delete
 [SOFT_DELETE_TO_HISTORY]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#soft_delete_to_history

--- a/docs/fivetran/overview.md
+++ b/docs/fivetran/overview.md
@@ -77,7 +77,7 @@ We use the following data type conversions:
   key constraints while they go.
 
   This will effectively impact the schema migration operations [HISTORY_TO_SOFT_DELETE],
-  [SOFT_DELETE_TO_HISTORY], [HISTORY_TO_LIVE], and [LIVE_TO_HISTORY].
+  [SOFT_DELETE_TO_HISTORY].
 
 - Certain column names are reserved for system purposes, so they will be rejected for users.
   Example: `InvalidColumnNameException["_id" conflicts with system column]`.
@@ -91,5 +91,3 @@ We use the following data type conversions:
 
 [HISTORY_TO_SOFT_DELETE]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#history_to_soft_delete
 [SOFT_DELETE_TO_HISTORY]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#soft_delete_to_history
-[HISTORY_TO_LIVE]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#history_to_live
-[LIVE_TO_HISTORY]: https://github.com/fivetran/fivetran_partner_sdk/blob/main/schema-migration-helper-service.md#live_to_history

--- a/docs/fivetran/setup-guide.md
+++ b/docs/fivetran/setup-guide.md
@@ -42,9 +42,7 @@ requirements.
 3. Enter a **Destination name** of your choice and then click **Add**.
 4. Select **CrateDB** as the destination type.
 5. In the destination setup form, enter the **URL** of your database cluster.
-6. Enumerate the steps from the destination setup form.
-7. List one action per step.
-8. Click **Save & Test**.
+6. Click **Save & Test**.
 
    Fivetran [tests and validates]
    the database connection. Upon successfully completing the setup tests, you can

--- a/docs/fivetran/setup-guide.md
+++ b/docs/fivetran/setup-guide.md
@@ -1,0 +1,86 @@
+---
+name: Setup Guide
+title: CrateDB Setup Guide
+description: Setup Guide for CrateDB Fivetran Destination
+hidden: false
+---
+
+# CrateDB Setup Guide {% badge text="Partner-Built" /%} {% availabilityBadge connector="cratedb_destination" /%}
+
+Follow the setup guide to connect your CrateDB data warehouse to Fivetran.
+
+-----
+
+## Prerequisites
+
+To connect CrateDB as a [Destination] to Fivetran, you need the following:
+
+- Authentication credentials (hostname, username, password) for a CrateDB
+  or CrateDB Cloud database cluster.
+
+- A Fivetran role with the [Create Destinations or Manage Destinations] permissions
+
+-----
+
+## Setup instructions
+
+### <span class="step-item">Choose your deployment model</span>
+
+Before setting up your destination, decide which deployment model best suits
+your organization's requirements. This destination supports both SaaS,
+Hybrid, and Self-Hosted deployment models, offering flexibility to meet diverse compliance
+and data governance needs.
+
+See the [Deployment Models documentation] to understand the use cases of each
+model and choose the model that aligns with your security and operational
+requirements.
+
+### <span class="step-item"> Complete Fivetran configuration </span>
+
+1. Log in to your [Fivetran account].
+2. Go to the **Destinations** page and click **Add destination**.
+3. Enter a **Destination name** of your choice and then click **Add**.
+4. Select **CrateDB** as the destination type.
+5. In the destination setup form, enter the **URL** of your database cluster.
+6. Enumerate the steps from the destination setup form.
+7. List one action per step.
+8. Click **Save & Test**.
+
+   Fivetran [tests and validates]
+   the database connection. Upon successfully completing the setup tests, you can
+   sync your data using Fivetran connectors to the CrateDB destination.
+
+
+### Setup tests
+
+Fivetran performs the following connection tests:
+
+The Host Connection test checks the host's accessibility and validates the
+database credentials you provided in the setup form.
+  
+> NOTE: The tests may take a couple of minutes to complete.
+
+-----
+
+## Related articles
+
+[<i aria-hidden="true" class="material-icons">description</i> Destination Overview](/docs/destinations/cratedb)
+
+<b> </b>
+
+[<i aria-hidden="true" class="material-icons">assignment</i> Release Notes](/docs/destinations/cratedb/changelog)
+
+<b> </b>
+
+[<i aria-hidden="true" class="material-icons">settings</i> API Destination Configuration](/docs/destinations/cratedb/api-configuration)
+
+<b> </b>
+
+[<i aria-hidden="true" class="material-icons">home</i> Documentation Home](/docs/getting-started)
+
+
+[Create Destinations or Manage Destinations]: /docs/using-fivetran/fivetran-dashboard/account-settings/role-based-access-control#rbacpermissions
+[Deployment Models documentation]: /docs/deployment-models
+[Destination]: /docs/using-fivetran/fivetran-dashboard/destination
+[Fivetran account]: https://fivetran.com/login
+[tests and validates]: /docs/destinations/cratedb/setup-guide#setuptests

--- a/docs/fivetran/setup-guide.md
+++ b/docs/fivetran/setup-guide.md
@@ -15,10 +15,16 @@ Follow the setup guide to connect your CrateDB data warehouse to Fivetran.
 
 To connect CrateDB as a [Destination] to Fivetran, you need the following:
 
-- Authentication credentials (hostname, username, password) for a CrateDB
+- A database connection URL. Because the adapter uses SQLAlchemy, a database
+  connection URL like `crate://cratedb.example.net:4200` is the right choice.
+  When connecting to CrateDB Cloud using SSL, please add the `?ssl=true`
+  query parameter.
+
+- Authentication credentials username, password for your CrateDB
   or CrateDB Cloud database cluster.
 
-- A Fivetran role with the [Create Destinations or Manage Destinations] permissions
+- A Fivetran role with the [Create Destinations or Manage Destinations]
+  permissions.
 
 -----
 

--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -27,11 +27,6 @@ Start gRPC destination server. Note the parameters are optional.
 cratedb-fivetran-destination --port=50052 --max-workers=1
 ```
 
-## Standalone executables
-
-CI on this project created standalone executables for different architectures
-using [PyInstaller], and publishes them on its [releases] page.
-
 ## Container use
 
 Start CrateDB.

--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -33,21 +33,20 @@ Start CrateDB.
 ```shell
 docker run --rm \
   --publish=4200:4200 --publish=5432:5432 --env=CRATE_HEAP_SIZE=2g \
-  docker.io/crate:latest '-Cdiscovery.type=single-node'
+  docker.io/crate:6.2.4 '-Cdiscovery.type=single-node'
 ```
 
 Start Fivetran gRPC destination server.
 ```bash
 docker run --rm \
   --publish=50052:50052 \
-  ghcr.io/crate/cratedb-fivetran-destination:nightly
+  ghcr.io/crate/cratedb-fivetran-destination:latest
 ```
 
 CI is building image variants for each pr, each night, and for
 GA releases, covering many situations of the development cycle.
-
-Please use container image tags appropriately when aiming for version pinning.
-The first GA release will be `cratedb-fivetran-destination:0.0.1`.
+Please use container image tags appropriately when aiming for
+version pinning.
 
 OCI image: [ghcr.io/crate/cratedb-fivetran-destination]
 

--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -34,8 +34,14 @@ using [PyInstaller], and publishes them on its [releases] page.
 
 ## Container use
 
-Invoke the OCI image [ghcr.io/crate/cratedb-fivetran-destination] at your
-disposal, for example using Docker.
+Start CrateDB.
+```shell
+docker run --rm \
+  --publish=4200:4200 --publish=5432:5432 --env=CRATE_HEAP_SIZE=2g \
+  docker.io/crate:latest '-Cdiscovery.type=single-node'
+```
+
+Start Fivetran gRPC destination server.
 ```bash
 docker run --rm \
   --publish=50052:50052 \
@@ -43,10 +49,12 @@ docker run --rm \
 ```
 
 CI is building image variants for each pr, each night, and for
-GA releases, covering in many situations of the development cycle.
+GA releases, covering many situations of the development cycle.
 
 Please use container image tags appropriately when aiming for version pinning.
 The first GA release will be `cratedb-fivetran-destination:0.0.1`.
+
+OCI image: [ghcr.io/crate/cratedb-fivetran-destination]
 
 ## Caveats
 

--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -13,6 +13,8 @@ The project provides installation artefacts per [PyPI package][PyPI] and
 [OCI image], you can invoke the adapter by installing it persistently
 first, or by running it ephemerally using its container image.
 
+Note: **Operating the package needs CrateDB 6.2 or higher.**
+
 ## Persistent installation
 
 Install package. [^uv]


### PR DESCRIPTION
## About
Fundamental documentation about the CrateDB adapter,
aiming to add CrateDB to the [list of supported destinations](https://fivetran.com/docs/destinations),
to be improved as we go.

## Review
@rajat-kushwaha, @matriv, @surister, @hammerhead, @grbade, @joerg84: Please also let us know about what comes to your mind about this. Any suggestions are welcome.

## References
- GH-147
