### PR TITLE
Testing: Update to `sdk-tester:2.26.0127.001` (Jan 28, 2026)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,26 +14,34 @@ concurrency:
 
 jobs:
   test:
-    name: "Python: ${{ matrix.python-version }}
-     on ${{ matrix.os }}"
+    name: "
+    CrateDB: ${{ matrix.cratedb-version }}
+    SDK: ${{ matrix.sdk-tester-version }}
+    "
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
         python-version: [
-          '3.9',
           '3.14',
         ]
-        cratedb-version: ['nightly']
+        cratedb-version:
+          - '6.3.1'
+          #- 'nightly'  # Currently defunct. https://github.com/crate/crate/issues/19291
+        sdk-tester-version:
+          - '2.26.0113.001'  # LIVE mode active
+          - '2.26.0127.001'  # LIVE mode paused
 
     env:
+      CRATEDB_VERSION: '${{ matrix.cratedb-version }}'
+      SDK_TESTER_VERSION: '${{ matrix.sdk-tester-version }}'
       UV_PYTHON_DOWNLOADS: never
       UV_SYSTEM_PYTHON: true
 
     services:
       cratedb:
-        image: docker.io/crate/crate:6.3.1
+        image: docker.io/crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Added refinements from recent commits to Fivetran Partner SDK
   up until commit ee4e282d.
+- Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
 
 ## v0.0.4 - 2026-01-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Added refinements from recent commits to Fivetran Partner SDK
   up until commit ee4e282d.
 - Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
+- Testing: Skipped live mode integration test, the feature has
+  been put [on hold][live mode pause] by Fivetran.
+
+[live mode pause]: https://github.com/crate/cratedb-fivetran-destination/issues/148
 
 ## v0.0.4 - 2026-01-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
 - Testing: Skipped live mode integration test, the feature has
   been put [on hold][live mode pause] by Fivetran.
+- Dependencies: Updated to grpcio >= 1.78
 
 [live mode pause]: https://github.com/crate/cratedb-fivetran-destination/issues/148
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ optional-dependencies.test = [
   "pretend<2",
   "pytest<10",
   "pytest-mock<4",
+  "verlib2<0.4",
 ]
 urls."Release Notes" = "https://github.com/crate/cratedb-fivetran-destination/releases"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,13 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "grpcio-tools<1.79",
+  "grpcio-tools>=1.78,<1.79",
   "setuptools>=42",
 ]
 
 [project]
 name = "cratedb-fivetran-destination"
 version = "0.0.4"
-
 description = "CrateDB Fivetran Destination"
 readme = "README.md"
 keywords = [
@@ -73,7 +72,7 @@ dependencies = [
   "attrs<26",
   "click<9",
   "google<3.1",
-  "grpcio<1.79",
+  "grpcio>=1.78,<1.79",
   "grpcio-tools<1.79",
   "protobuf<6.34",
   "pycryptodome<3.24",

--- a/src/cratedb_fivetran_destination/testing.py
+++ b/src/cratedb_fivetran_destination/testing.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 # https://console.cloud.google.com/artifacts/docker/build-286712/us/public-docker-us/sdktesters-v2%2Fsdk-tester?pli=1
 
 SDK_TESTER_OCI = (
-    "us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:2.26.0113.001"
+    "us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:2.26.0127.001"
 )
 
 

--- a/src/cratedb_fivetran_destination/testing.py
+++ b/src/cratedb_fivetran_destination/testing.py
@@ -13,8 +13,9 @@ logger = logging.getLogger()
 # Check for recent releases:
 # https://console.cloud.google.com/artifacts/docker/build-286712/us/public-docker-us/sdktesters-v2%2Fsdk-tester?pli=1
 
+SDK_TESTER_VERSION = "2.26.0127.001"
 SDK_TESTER_OCI = (
-    "us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:2.26.0127.001"
+    f"us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:{SDK_TESTER_VERSION}"
 )
 
 

--- a/src/cratedb_fivetran_destination/testing.py
+++ b/src/cratedb_fivetran_destination/testing.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import typing as t
 from pathlib import Path
@@ -13,7 +14,8 @@ logger = logging.getLogger()
 # Check for recent releases:
 # https://console.cloud.google.com/artifacts/docker/build-286712/us/public-docker-us/sdktesters-v2%2Fsdk-tester?pli=1
 
-SDK_TESTER_VERSION = "2.26.0127.001"
+SDK_TESTER_VERSION_DEFAULT = "2.26.0127.001"  # (Jan 28, 2026)
+SDK_TESTER_VERSION = os.getenv("SDK_TESTER_VERSION", SDK_TESTER_VERSION_DEFAULT)
 SDK_TESTER_OCI = (
     f"us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:{SDK_TESTER_VERSION}"
 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,11 +8,22 @@ import sqlalchemy as sa
 from sqlalchemy.sql.type_api import UserDefinedType
 from sqlalchemy.testing.util import drop_all_tables
 from sqlalchemy_cratedb import ObjectType
+from verlib2 import Version
 
-from cratedb_fivetran_destination.testing import SDK_TESTER_OCI, get_sdk_tester_command
+from cratedb_fivetran_destination.testing import (
+    SDK_TESTER_OCI,
+    SDK_TESTER_VERSION,
+    get_sdk_tester_command,
+)
 from tests.conftest import unblock_all_tables
 
 pytestmark = pytest.mark.sdktester
+
+# LIVE mode was paused by Fivetran.
+# Failed to process file: schema_migrations_input_sync_modes.json
+# History to Live mode migration is not supported.
+# https://github.com/crate/cratedb-fivetran-destination/issues/148
+SDK_TESTER_VERSION_SCHEMA_MIGRATIONS_CUTOFF = "2.26.0127.001"
 
 
 def run(command, background: bool = False):
@@ -152,6 +163,12 @@ def test_integration_fivetran_migrations_dml(capfd, services):
     assert "Describe Table: transaction_renamed" in err
 
 
+@pytest.mark.skipif(
+    Version(SDK_TESTER_VERSION) >= Version(SDK_TESTER_VERSION_SCHEMA_MIGRATIONS_CUTOFF),
+    reason=f"SDK tester version {SDK_TESTER_VERSION_SCHEMA_MIGRATIONS_CUTOFF} and higher "
+    f"rejects schema migrations: Failed to process file: History to Live mode migration "
+    f"is not supported.",
+)
 @pytest.mark.parametrize("services", ["./tests/data/fivetran_migrations_sync"], indirect=True)
 def test_integration_fivetran_migrations_sync(capfd, services):
     """


### PR DESCRIPTION
## About
Regular maintenance, updating the Fivetran destination SDK tester.

## Details
This time, it is special that Fivetran retracted the _live mode_ feature, so let's add a quick test matrix configuration to keep up code coverage and skip the corresponding test case on newer SDK tester versions.

## References
- GH-148

/cc @fivetran-anushkaparashar, @seut 