### PR TITLE
CI: Downgrade to CrateDB 6.3.1, nightly observes a regression

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
 
     services:
       cratedb:
-        image: docker.io/crate/crate:nightly
+        image: docker.io/crate/crate:6.3.1
         ports:
           - 4200:4200
           - 5432:5432


### PR DESCRIPTION
## About
Use CrateDB 6.3.1 on CI, because CrateDB nightly has problems with `TO_CHAR`.

## References
- https://github.com/crate/crate/issues/19291

/cc @seut, @matriv 