### PR TITLE
Dependencies: Update to grpcio==1.78.*

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - Testing: Updated to `sdk-tester:2.26.0127.001` (Jan 28, 2026)
 - Testing: Skipped live mode integration test, the feature has
   been put [on hold][live mode pause] by Fivetran.
-- Dependencies: Updated to grpcio >= 1.78
+- Dependencies: Updated to grpcio==1.78.*
 
 [live mode pause]: https://github.com/crate/cratedb-fivetran-destination/issues/148
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "grpcio-tools>=1.78,<1.79",
+  "grpcio-tools==1.78.*",
   "setuptools>=42",
 ]
 
@@ -71,8 +71,7 @@ dependencies = [
   "attrs<26",
   "click<9",
   "google<3.1",
-  "grpcio>=1.78,<1.79",
-  "grpcio-tools<1.79",
+  "grpcio==1.78.*",
   "protobuf<6.34",
   "pycryptodome<3.24",
   "python-dateutil<2.10",


### PR DESCRIPTION
It is better to pin to a specific minor version range of grpcio.