### PR TITLE
Fix schema migration helper's `_validate_history_table`, and use CrateDB nightly again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
           '3.14',
         ]
         cratedb-version:
-          - '6.3.1'
-          #- 'nightly'  # Currently defunct. https://github.com/crate/crate/issues/19291
+          #- '6.3.1'
+          - 'nightly'
         sdk-tester-version:
           - '2.26.0113.001'  # (Jan 16, 2026) LIVE mode active
           - '2.26.0127.001'  # (Jan 28, 2026) LIVE mode paused

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fixed schema migration helper's `_validate_history_table` by using `DATE_FORMAT`
+  instead of `TO_CHAR`. Because live mode was paused, this doesn't have an effect
+  on usability today.
+
 ## v0.1.0 - 2026-04-24
 
 - Model: Removed workaround for `_`-prefixed column names.

--- a/src/cratedb_fivetran_destination/schema_migration_helper.py
+++ b/src/cratedb_fivetran_destination/schema_migration_helper.py
@@ -805,7 +805,7 @@ class SchemaMigrationHelper:
 
             # Validate operation timestamp condition.
             sql = f"""
-            SELECT TO_CHAR(MAX({FIVETRAN_START}), 'YYYY-MM-DDTHH:MI:SSZ') AS max_start
+            SELECT DATE_FORMAT('%Y-%m-%dT%H:%i:%sZ', MAX({FIVETRAN_START})) AS max_start
             FROM "{schema}"."{table}"
             WHERE {FIVETRAN_ACTIVE} = TRUE
             """


### PR DESCRIPTION
## About

Use `DATE_FORMAT` instead of `TO_CHAR`. Because live mode was paused, this doesn't have an effect on usability today, but will still be validated on CI through the combination of Fivetran SDK tester version `2.26.0113.001` (which still provides test cases for live mode) with CrateDB nightly and higher.

## References

- https://github.com/crate/crate/issues/19291
- GH-169
