### PR TITLE
Harmonize drivers to `crate<2.2`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Harmonized drivers by downgrading to `crate<2.2`
+
 ## v0.1.2 - 2026-05-08
 
 - Added `Capabilities` RPC endpoint, returning `BatchFileFormat.CSV`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ classifiers = [
 dependencies = [
   "attrs<27",
   "click<9",
+  "crate<2.2",
   "google<3.1",
   "grpcio==1.81.*",
   "protobuf<7.36",


### PR DESCRIPTION
## Problem
The nightly scheduled CI run started failing with those errors, amongst others.
```
crate.client.exceptions.ProgrammingError:
ColumnUnknownException[Column data unknown]
```

## Solution
Use previous driver release `crate==2.1.*`.

## References
- https://github.com/crate/crate-python/issues/815

/cc @bgunebakan, @kneth 